### PR TITLE
科目番号前方一致検索

### DIFF
--- a/__tests__/usecase/searchCourse.test.ts
+++ b/__tests__/usecase/searchCourse.test.ts
@@ -100,10 +100,11 @@ beforeAll(async () => {
   )
 })
 
-test('キーワード検索単体', async () => {
+test('キーワード検索単体(科目番号指定なし)', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: ['情報'],
+    codes: [],
     searchMode: SearchMode.Cover,
     offset: 0,
     limit: 30,
@@ -113,10 +114,11 @@ test('キーワード検索単体', async () => {
   res.forEach((c) => expect(c.name.includes('情報')).toBe(true))
 })
 
-test('キーワード複数', async () => {
+test('キーワード複数(科目番号指定なし)', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: ['情報', '人工知能'],
+    codes: [],
     searchMode: SearchMode.Cover,
     offset: 0,
     limit: 30,
@@ -128,10 +130,57 @@ test('キーワード複数', async () => {
   )
 })
 
+test('科目番号指定(キーワード指定なし)', async () => {
+  const res = await searchCourseUseCase({
+    year: 2020,
+    keywords: [],
+    codes: ['FF'],
+    searchMode: SearchMode.Cover,
+    offset: 0,
+    limit: 30,
+  })
+  expect(res.length > 0).toBe(true)
+  expect(res.length <= 30).toBe(true)
+  res.forEach((c) => expect(c.code.startsWith('FF')).toBe(true))
+})
+
+test('科目番号指定複数(キーワード指定なし)', async () => {
+  const res = await searchCourseUseCase({
+    year: 2020,
+    keywords: [],
+    codes: ['FF', 'GB'],
+    searchMode: SearchMode.Cover,
+    offset: 0,
+    limit: 30,
+  })
+  expect(res.length > 0).toBe(true)
+  expect(res.length <= 30).toBe(true)
+  res.forEach((c) =>
+    expect(c.code.startsWith('FF') || c.code.startsWith('GB')).toBe(true)
+  )
+})
+
+test('キーワード指定&科目番号指定', async () => {
+  const res = await searchCourseUseCase({
+    year: 2020,
+    keywords: ['科学'],
+    codes: ['FF'],
+    searchMode: SearchMode.Cover,
+    offset: 0,
+    limit: 30,
+  })
+  expect(res.length > 0).toBe(true)
+  expect(res.length <= 30).toBe(true)
+  res.forEach((c) =>
+    expect(c.name.includes('科学') && c.code.startsWith('FF')).toBe(true)
+  )
+})
+
 test('キーワードなしで全部', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Cover,
     offset: 0,
     limit: initialData.length,
@@ -145,6 +194,7 @@ test('不正なoffset', () => {
     searchCourseUseCase({
       year: 2020,
       keywords: ['情報'],
+      codes: [],
       searchMode: SearchMode.Cover,
       offset: -1,
       limit: 30,
@@ -157,6 +207,7 @@ test('不正なlimit', () => {
     searchCourseUseCase({
       year: 2020,
       keywords: ['情報'],
+      codes: [],
       searchMode: SearchMode.Cover,
       offset: 0,
       limit: 0,
@@ -168,6 +219,7 @@ test('時間割 contain1', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Contain,
     timetable: {
       SpringA: {
@@ -194,6 +246,7 @@ test('時間割 contain2', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Contain,
     timetable: {
       SpringA: {
@@ -220,6 +273,7 @@ test('時間割 contain3', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Contain,
     timetable: {
       SpringA: fillAllDayWith(new Array(7).fill(true)),
@@ -242,6 +296,7 @@ test('時間割 contain4', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Contain,
     timetable: fillAllModuleWith({
       Intensive: [true, false, false, false, false, false, false],
@@ -260,6 +315,7 @@ test('時間割 cover1', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Cover,
     timetable: {
       SpringA: {
@@ -282,6 +338,7 @@ test('時間割 cover2', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Cover,
     timetable: {
       SpringA: {
@@ -304,6 +361,7 @@ test('時間割 cover3', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Cover,
     timetable: {
       SpringA: fillAllDayWith(new Array(7).fill(true)),
@@ -320,6 +378,7 @@ test('時間割 cover4', async () => {
   const res = await searchCourseUseCase({
     year: 2020,
     keywords: [],
+    codes: [],
     searchMode: SearchMode.Cover,
     timetable: fillAllModuleWith({
       Intensive: new Array(8).fill(true),

--- a/protos/CourseService.proto
+++ b/protos/CourseService.proto
@@ -146,6 +146,7 @@ message SearchCourseRequestTimetable {
 message SearchCourseRequest {
   int32 year = 1;
   repeated string keywords = 2;
+  repeated string codes = 7;
   SearchCourseRequestTimetable timetable = 3;
   enum SearchMode {
     Cover = 0;


### PR DESCRIPTION
キーワードに `情報` `人工知能` 科目番号に `GA` `GB` と指定すると
`情報` と `人工知能` を講義名に含み、 `GA` か `GB` で始まる講義
が検索できる。